### PR TITLE
Fix Vercel build with MUI 9

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,7 +10,7 @@ import {
   CardContent,
   TextField,
   Button,
-  Grid2 as Grid,
+  Grid,
   Table,
   TableBody,
   TableCell,

--- a/src/app/desktop/DesktopAppPage.tsx
+++ b/src/app/desktop/DesktopAppPage.tsx
@@ -7,7 +7,7 @@ import {
   Container,
   Typography,
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import DownloadIcon from '@mui/icons-material/Download';
 import AppleIcon from '@mui/icons-material/Apple';
 import DesktopWindowsIcon from '@mui/icons-material/DesktopWindows';

--- a/src/app/newsletter/page.tsx
+++ b/src/app/newsletter/page.tsx
@@ -1,10 +1,8 @@
-import Link from 'next/link';
 import { getPublishedIssuesList } from '@/lib/content/issues';
 import {
   Box,
   Container,
   Typography,
-  Button,
   Link as MuiLink,
   Stack,
 } from '@mui/material';
@@ -13,6 +11,7 @@ import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import CodeIcon from '@mui/icons-material/Code';
 import { palette } from '@/theme/theme';
+import ButtonLink from '@/components/ButtonLink';
 
 export const metadata = {
   title: 'Vector Log — Newsletter for AI Builders',
@@ -159,8 +158,7 @@ export default async function NewsletterIndexPage() {
             One email every two weeks. Unsubscribe anytime. We only use your address for the
             newsletter.
           </Typography>
-          <Button
-            component={Link}
+          <ButtonLink
             href="/newsletter/subscribe"
             variant="contained"
             size="large"
@@ -177,7 +175,7 @@ export default async function NewsletterIndexPage() {
             }}
           >
             Subscribe — it&apos;s free
-          </Button>
+          </ButtonLink>
         </Box>
 
         {/* What you get — GTM benefit bullets */}
@@ -275,7 +273,6 @@ export default async function NewsletterIndexPage() {
                     }}
                   >
                     <MuiLink
-                      component={Link}
                       href={`/newsletter/${issue.issueNumber}`}
                       underline="hover"
                       sx={{
@@ -332,8 +329,7 @@ export default async function NewsletterIndexPage() {
           <Typography sx={{ color: palette.textMuted, fontSize: 14, mb: 2, lineHeight: 1.5 }}>
             Get Vector Log in your inbox. No spam — just developer-focused AI notes, bi-weekly.
           </Typography>
-          <Button
-            component={Link}
+          <ButtonLink
             href="/newsletter/subscribe"
             variant="contained"
             sx={{
@@ -348,7 +344,7 @@ export default async function NewsletterIndexPage() {
             }}
           >
             Subscribe to Vector Log
-          </Button>
+          </ButtonLink>
         </Box>
       </Container>
     </Box>

--- a/src/app/newsletter/subscribe/page.tsx
+++ b/src/app/newsletter/subscribe/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { Box, Container, Typography } from '@mui/material';
 import { palette } from '@/theme/theme';
 
@@ -7,7 +6,7 @@ export default function NewsletterSubscribePage() {
     <Box sx={{ py: 8, minHeight: '70vh' }}>
       <Container maxWidth="sm">
         <Typography
-          component={Link}
+          component="a"
           href="/newsletter"
           sx={{
             display: 'inline-block',

--- a/src/app/shared-space/page.tsx
+++ b/src/app/shared-space/page.tsx
@@ -17,7 +17,7 @@ import {
   Snackbar,
   Alert,
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { palette } from '@/theme/theme';

--- a/src/app/telemetry/dashboard/page.tsx
+++ b/src/app/telemetry/dashboard/page.tsx
@@ -7,7 +7,7 @@ import {
   Typography,
 } from '@mui/material';
 import ButtonLink from '@/components/ButtonLink';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined';
 import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
 import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';

--- a/src/app/telemetry/page.tsx
+++ b/src/app/telemetry/page.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from '@mui/material';
 import ButtonLink from '@/components/ButtonLink';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';

--- a/src/app/workflows/[slug]/page.tsx
+++ b/src/app/workflows/[slug]/page.tsx
@@ -5,7 +5,7 @@ import {
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
   Paper, IconButton, Tooltip, Button, Stack,
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';

--- a/src/app/workflows/page.tsx
+++ b/src/app/workflows/page.tsx
@@ -4,7 +4,7 @@ import {
   Box, Container, Typography, TextField, InputAdornment, Stack,
   IconButton, ToggleButtonGroup, ToggleButton,
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import SearchIcon from '@mui/icons-material/Search';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';

--- a/src/components/DesktopApp.tsx
+++ b/src/components/DesktopApp.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, Button, Chip, Container, Typography } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import DownloadIcon from '@mui/icons-material/Download';
 import AppleIcon from '@mui/icons-material/Apple';
 import DesktopWindowsIcon from '@mui/icons-material/DesktopWindows';
@@ -32,7 +32,7 @@ export default function DesktopApp() {
   return (
     <Box component="section" id="desktop" sx={{ py: { xs: 8, md: 12 } }}>
       <Container maxWidth="lg">
-        <Grid container spacing={6} alignItems="center">
+        <Grid container spacing={6} sx={{ alignItems: 'center' }}>
           <Grid size={{ xs: 12, md: 6 }}>
             <Chip
               label="Desktop App"

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, Card, CardContent, Container, Typography, Link } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import BoltIcon from '@mui/icons-material/Bolt';
 import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import ImageIcon from '@mui/icons-material/Image';

--- a/src/components/McpServer.tsx
+++ b/src/components/McpServer.tsx
@@ -12,7 +12,7 @@ import {
   Tab,
   Typography,
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import SearchIcon from '@mui/icons-material/Search';

--- a/src/components/SiteSearch.tsx
+++ b/src/components/SiteSearch.tsx
@@ -139,16 +139,18 @@ export default function SiteSearch() {
         onClose={closeSearch}
         fullWidth
         maxWidth="sm"
-        PaperProps={{
-          sx: {
-            position: 'fixed',
-            top: isMobile ? '10%' : 80,
-            mx: 'auto',
-            borderRadius: 2,
-            bgcolor: palette.bgCard,
-            border: `1px solid ${palette.border}`,
-            boxShadow: '0 24px 48px rgba(0,0,0,0.4)',
-            overflow: 'hidden',
+        slotProps={{
+          paper: {
+            sx: {
+              position: 'fixed',
+              top: isMobile ? '10%' : 80,
+              mx: 'auto',
+              borderRadius: 2,
+              bgcolor: palette.bgCard,
+              border: `1px solid ${palette.border}`,
+              boxShadow: '0 24px 48px rgba(0,0,0,0.4)',
+              overflow: 'hidden',
+            },
           },
         }}
       >
@@ -207,21 +209,23 @@ export default function SiteSearch() {
                 <ListItemText
                   primary={entry.title}
                   secondary={entry.description}
-                  primaryTypographyProps={{
-                    sx: {
-                      fontWeight: 600,
-                      fontSize: '0.95rem',
-                      color: palette.text,
+                  slotProps={{
+                    primary: {
+                      sx: {
+                        fontWeight: 600,
+                        fontSize: '0.95rem',
+                        color: palette.text,
+                      },
                     },
-                  }}
-                  secondaryTypographyProps={{
-                    sx: {
-                      fontSize: '0.8rem',
-                      color: palette.textMuted,
-                      display: '-webkit-box',
-                      WebkitLineClamp: 2,
-                      WebkitBoxOrient: 'vertical',
-                      overflow: 'hidden',
+                    secondary: {
+                      sx: {
+                        fontSize: '0.8rem',
+                        color: palette.textMuted,
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                      },
                     },
                   }}
                 />

--- a/src/components/WhyVoyageAI.tsx
+++ b/src/components/WhyVoyageAI.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, Container, Typography, Chip } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import SavingsIcon from '@mui/icons-material/Savings';
 import HubIcon from '@mui/icons-material/Hub';

--- a/src/components/admin/UnsplashImagePicker.tsx
+++ b/src/components/admin/UnsplashImagePicker.tsx
@@ -170,7 +170,7 @@ export default function UnsplashImagePicker({
         <Box sx={{ mt: 2, maxHeight: 420, overflowY: 'auto' }}>
           <Grid container spacing={1.5}>
             {images.map((img) => (
-              <Grid item xs={6} sm={4} md={3} key={img.id}>
+              <Grid size={{ xs: 6, sm: 4, md: 3 }} key={img.id}>
                 <Card
                   sx={{
                     bgcolor: palette.bgCard,

--- a/src/components/demos/DemoCard.tsx
+++ b/src/components/demos/DemoCard.tsx
@@ -346,7 +346,7 @@ export default function DemoCard({ demo }: DemoCardProps) {
             </Typography>
           </Box>
 
-          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
             <Button
               variant="outlined"
               size="small"

--- a/src/components/demos/DemoDetailPage.tsx
+++ b/src/components/demos/DemoDetailPage.tsx
@@ -15,7 +15,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import CloseIcon from '@mui/icons-material/Close';

--- a/src/components/demos/LabCompanionPanel.tsx
+++ b/src/components/demos/LabCompanionPanel.tsx
@@ -21,7 +21,7 @@ export default function LabCompanionPanel({ lab }: LabCompanionPanelProps) {
         mb: 4,
       }}
     >
-      <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mb: 1 }}>
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 1 }}>
         <MenuBookIcon sx={{ color: palette.accent, fontSize: 24 }} />
         <Typography variant="h5" sx={{ color: palette.text, fontWeight: 700 }}>
           Lab companion

--- a/src/components/telemetry/PublicTelemetryDashboard.tsx
+++ b/src/components/telemetry/PublicTelemetryDashboard.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
 import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined';
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined';

--- a/src/components/telemetry/PublicTelemetryMethodology.tsx
+++ b/src/components/telemetry/PublicTelemetryMethodology.tsx
@@ -8,7 +8,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Grid';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,13 +11,13 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [{ "name": "next" }],
     "paths": {
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- migrate removed MUI Grid2 and deprecated component props to MUI 9 APIs
- keep newsletter navigation serializable across Next.js server/client boundaries
- apply Next.js 16 TypeScript configuration requirements

## Test plan
- [x] Run `npm ci`
- [x] Run `npm run build`
- [x] Confirm all 64 static pages generate successfully

Made with [Cursor](https://cursor.com)